### PR TITLE
Dockerfile: Remove hostapp.test from artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=target=. \
        make DEST=/out mobynit hostapp.test
 
 FROM scratch AS final
-COPY --from=gobuild /out/* /
+COPY --from=gobuild /out/mobynit /
 
 FROM docker:19.03-dind AS testimage
 RUN apk add bash sudo util-linux


### PR DESCRIPTION
Leave only the mobynit binary as release artifacts.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>