### PR TITLE
Makefile: Remove disabling cgo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM --platform=${BUILDPLATFORM} docker.io/tonistiigi/xx:golang AS xx
 FROM --platform=${BUILDPLATFORM} golang:alpine AS gobuild
 
-RUN apk add make
+RUN apk add make gcc libc-dev
 
 WORKDIR /src
 

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,12 @@ DOCKER_BUILDTAGS ?= no_btrfs no_cri no_zfs exclude_disk_quota exclude_graphdrive
 GO_BUILDTAGS ?= netgo osusergo static_build $(DOCKER_BUILDTAGS)
 
 mobynit:
-	CGO_ENABLED=0 \
 	$(GO) build -o $(DEST)/$@ \
 		-ldflags "$(GO_LDFLAGS)" \
 		-tags "$(GO_BUILDTAGS)" \
 		./cmd/mobynit
 
 hostapp.test:
-	CGO_ENABLED=0 \
 	$(GO) test -c -o $(DEST)/$@ \
 		-ldflags "$(GO_LDFLAGS)" \
 		-tags "$(GO_BUILDTAGS)"


### PR DESCRIPTION
CGO is required when cross-compiling mobyinit, so with CGO_ENABLED=0 the
Yocto builds fail.

This commit removes the CGO_ENABLED=0 and add the requires dependencies
to the CI container to use CGO.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>