### PR TITLE
hostapp: add kernel version ABI extension filtering

### DIFF
--- a/cmd/mobynit/main.go
+++ b/cmd/mobynit/main.go
@@ -152,6 +152,24 @@ func mountDataOverlays(newRootPath string) error {
 		return nil
 	}
 
+	// An empty release (e.g. uname failed) disables the version filter
+	release, err := hostapp.GetKernelRelease()
+	if err != nil {
+		log.Printf("Warning: could not get kernel release: %v", err)
+	}
+
+	cmdline, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		log.Printf("Warning: could not read /proc/cmdline: %v", err)
+	}
+	hostABIID := hostapp.ParseHostKernelABIID(string(cmdline))
+
+	containers = hostapp.SelectMountable(containers, release, hostABIID)
+	if len(containers) == 0 {
+		log.Println("No extensions compatible with running kernel, skipping overlay")
+		return nil
+	}
+
 	var leftExtensions, rightExtensions []hostapp.Extension
 
 	for _, container := range containers {

--- a/hostapp.go
+++ b/hostapp.go
@@ -1,8 +1,11 @@
 package hostapp
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -34,6 +37,7 @@ type Config struct {
 type Container struct {
 	Config
 	MountPath string
+	HomePath  string
 }
 
 var (
@@ -115,6 +119,22 @@ func (container *Container) mount(layerRoot string) (string, error) {
 	return container.MountPath, nil
 }
 
+// unmount releases the container's overlay filesystem. It is a no-op for a
+// container that was never mounted (MountPath == "").
+func (container *Container) unmount() error {
+	if container.MountPath == "" {
+		return nil
+	}
+	if err := unix.Unmount(container.MountPath, 0); err != nil {
+		return fmt.Errorf("unmounting %s: %w", container.MountPath, err)
+	}
+	if Debug {
+		log.Printf("Unmounted ID %s from %s", container.ID, container.MountPath)
+	}
+	container.MountPath = ""
+	return nil
+}
+
 // initialize reads container config
 func (container *Container) initialize(homePath string) error {
 	configPath := filepath.Join(homePath, "config.v2.json")
@@ -127,6 +147,7 @@ func (container *Container) initialize(homePath string) error {
 	if err := json.NewDecoder(f).Decode(&container.Config); err != nil {
 		return fmt.Errorf("decoding %s: %w", configPath, err)
 	}
+	container.HomePath = homePath
 	if Verbose || Debug {
 		log.Println("Initialized container:", container.Config.Name)
 	}
@@ -192,7 +213,178 @@ func Mount(rootdir string, label string) ([]Container, error) {
 	return initializeContainers(rootdir, label)
 }
 
-const HOSTOS_BLOCKS_OVERRIDE = "io.balena.image.override"
+const (
+	HOSTOS_BLOCKS_OVERRIDE       = "io.balena.image.override"
+	HOSTOS_BLOCKS_KERNEL_VERSION = "io.balena.image.kernel-version"
+	HOSTOS_BLOCKS_KERNEL_ABI_ID  = "io.balena.image.kernel-abi-id"
+	CMDLINE_KERNEL_ABI           = "balena_kernel_abi"
+)
+
+// ParseHostKernelABIID extracts the balena_kernel_abi=<value> token from a
+// kernel cmdline string and returns its value. Returns "" when the token is
+// absent or carries an empty value, i.e. when the boot path ran a stock
+// kernel whose ABI is not knowable.
+func ParseHostKernelABIID(cmdline string) string {
+	prefix := CMDLINE_KERNEL_ABI + "="
+	for _, tok := range strings.Fields(cmdline) {
+		if v, ok := strings.CutPrefix(tok, prefix); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// GetKernelRelease returns the running kernel's full release string
+// (e.g. "6.8.0-100-generic"), as reported by uname(2).
+func GetKernelRelease() (string, error) {
+	var utsname unix.Utsname
+	if err := unix.Uname(&utsname); err != nil {
+		return "", fmt.Errorf("uname syscall failed: %w", err)
+	}
+	return unix.ByteSliceToString(utsname.Release[:]), nil
+}
+
+// kernelVersionFromRelease strips the local-version suffix (e.g. "-100-generic",
+// "-v8+") from a uname release, leaving the M.m.p version that kernel-version
+// compatibility tracks. An empty release yields an empty version.
+func kernelVersionFromRelease(release string) string {
+	if idx := strings.IndexByte(release, '-'); idx > 0 {
+		return release[:idx]
+	}
+	return release
+}
+
+// FilterByKernelVersion removes containers whose kernel-version label
+// doesn't match the running kernel. Containers without the label always pass.
+// An empty kernelVersion disables filtering.
+func FilterByKernelVersion(containers []Container, kernelVersion string) []Container {
+	if kernelVersion == "" {
+		return containers
+	}
+	var filtered []Container
+	for _, c := range containers {
+		if labelVal, ok := c.Labels[HOSTOS_BLOCKS_KERNEL_VERSION]; ok && labelVal != kernelVersion {
+			log.Printf("Skipping container %s: kernel version %q != running %q", c.Name, labelVal, kernelVersion)
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	return filtered
+}
+
+// ComputeABIID returns the hex-encoded sha256 of the file at path.
+// Used to derive io.balena.image.kernel-abi-id from Module.symvers.
+func ComputeABIID(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hashing %s: %w", path, err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// ResolveExtensionABIID computes the container's kernel ABI ID as
+// sha256(<mount>/lib/modules/<release>/Module.symvers), where release is the
+// running kernel's uname release.
+//
+// Returns "" with no error if the extension carries no kernel modules for the
+// running release. Returns an error if /lib/modules/<release> exists
+// but Module.symvers is missing (broken extension), if the label disagrees with
+// the computed value, or if a module-carrying extension cannot be verified
+// because release is empty (running kernel unknown).
+func (c *Container) ResolveExtensionABIID(release string) (string, error) {
+	if c.MountPath == "" {
+		return "", nil
+	}
+
+	modulesRoot := filepath.Join(c.MountPath, "lib", "modules")
+	if _, err := os.Stat(modulesRoot); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("stat %s: %w", modulesRoot, err)
+	}
+
+	if release == "" {
+		return "", fmt.Errorf("extension %s: running kernel release unknown", c.Name)
+	}
+	modDir := filepath.Join(modulesRoot, release)
+	if _, err := os.Stat(modDir); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("stat %s: %w", modDir, err)
+	}
+	symversPath := filepath.Join(modDir, "Module.symvers")
+	if _, err := os.Stat(symversPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("broken extension %s: %s missing", c.Name, symversPath)
+		}
+		return "", fmt.Errorf("stat %s: %w", symversPath, err)
+	}
+	id, err := ComputeABIID(symversPath)
+	if err != nil {
+		return "", err
+	}
+	if labelVal, ok := c.Labels[HOSTOS_BLOCKS_KERNEL_ABI_ID]; ok && labelVal != "" && labelVal != id {
+		return "", fmt.Errorf("extension %s: %s label %q != computed %q",
+			c.Name, HOSTOS_BLOCKS_KERNEL_ABI_ID, labelVal, id)
+	}
+	return id, nil
+}
+
+// FilterByKernelABIID keeps only those containers safe to mount over the
+// running kernel.
+//
+// An ABI-agnostic extension makes no kernel-ABI claim and always passes.
+// A kernel-carrying extension is kept only when its computed ABI equals hostABIID.
+func FilterByKernelABIID(containers []Container, release, hostABIID string) []Container {
+	var filtered []Container
+	for i := range containers {
+		c := &containers[i]
+		id, err := c.ResolveExtensionABIID(release)
+		if err != nil {
+			log.Printf("Error: dropping container %s: %v", c.Name, err)
+			continue
+		}
+		if id == "" {
+			filtered = append(filtered, *c)
+			continue
+		}
+		if id != hostABIID {
+			log.Printf("Skipping container %s: kernel ABI ID %q != host %q", c.Name, id, hostABIID)
+			continue
+		}
+		filtered = append(filtered, *c)
+	}
+	return filtered
+}
+
+// SelectMountable filters the already-mounted extensions down to those
+// compatible with the running kernel, unmounting every extension it drops.
+// Survivors stay mounted for use as overlay lowerdirs.
+func SelectMountable(containers []Container, release, hostABIID string) []Container {
+	selected := FilterByKernelVersion(containers, kernelVersionFromRelease(release))
+	selected = FilterByKernelABIID(selected, release, hostABIID)
+
+	keep := make(map[string]bool, len(selected))
+	for _, c := range selected {
+		keep[c.MountPath] = true
+	}
+	for i := range containers {
+		if keep[containers[i].MountPath] {
+			continue
+		}
+		if err := containers[i].unmount(); err != nil {
+			log.Printf("Warning: failed to unmount dropped extension %s: %v", containers[i].Name, err)
+		}
+	}
+	return selected
+}
 
 // Extension represents an OS-block overlay extension. Extensions passed in
 // the leftExtensions slice of BuildOverlayOptions mount left of the hostapp

--- a/hostapp_test.go
+++ b/hostapp_test.go
@@ -2,10 +2,15 @@ package hostapp
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -742,4 +747,539 @@ func computeMD5(path string) (string, error) {
 	}
 	sum := md5.Sum(content)
 	return fmt.Sprintf("%x", sum), nil
+}
+
+// makeTestContainer builds a Container for table-driven filter tests.
+func makeTestContainer(name string, labels map[string]string) Container {
+	return Container{
+		Config: Config{
+			HostConfig: HostConfig{Labels: labels},
+			Name:       name,
+		},
+	}
+}
+
+func TestGetKernelRelease(t *testing.T) {
+	release, err := GetKernelRelease()
+	if err != nil {
+		t.Fatalf("GetKernelRelease failed: %v", err)
+	}
+	if release == "" {
+		t.Fatal("expected non-empty release")
+	}
+	if strings.ContainsRune(release, 0) {
+		t.Errorf("release contains NUL byte: %q", release)
+	}
+}
+
+func TestKernelVersionFromRelease(t *testing.T) {
+	tests := []struct {
+		release string
+		want    string
+	}{
+		{"6.8.0-100-generic", "6.8.0"},
+		{"6.1.0-v8+", "6.1.0"},
+		{"5.15.0", "5.15.0"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := kernelVersionFromRelease(tt.release); got != tt.want {
+			t.Errorf("kernelVersionFromRelease(%q) = %q, want %q", tt.release, got, tt.want)
+		}
+	}
+}
+
+func TestFilterByKernelVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		containers    []Container
+		kernelVersion string
+		expectNames   []string
+	}{
+		{
+			name: "no label passes through",
+			containers: []Container{
+				makeTestContainer("no-label", map[string]string{"io.balena.image.class": "overlay"}),
+			},
+			kernelVersion: "6.1.0",
+			expectNames:   []string{"no-label"},
+		},
+		{
+			name: "matching label passes",
+			containers: []Container{
+				makeTestContainer("match", map[string]string{HOSTOS_BLOCKS_KERNEL_VERSION: "6.1.0"}),
+			},
+			kernelVersion: "6.1.0",
+			expectNames:   []string{"match"},
+		},
+		{
+			name: "mismatched label filtered",
+			containers: []Container{
+				makeTestContainer("old", map[string]string{HOSTOS_BLOCKS_KERNEL_VERSION: "5.15.0"}),
+			},
+			kernelVersion: "6.1.0",
+			expectNames:   nil,
+		},
+		{
+			name: "mixed: keep matching and unlabelled, skip mismatched",
+			containers: []Container{
+				makeTestContainer("match", map[string]string{HOSTOS_BLOCKS_KERNEL_VERSION: "6.1.0"}),
+				makeTestContainer("old", map[string]string{HOSTOS_BLOCKS_KERNEL_VERSION: "5.15.0"}),
+				makeTestContainer("unlabelled", map[string]string{"io.balena.image.class": "overlay"}),
+			},
+			kernelVersion: "6.1.0",
+			expectNames:   []string{"match", "unlabelled"},
+		},
+		{
+			name: "empty kernel version passes all",
+			containers: []Container{
+				makeTestContainer("a", map[string]string{HOSTOS_BLOCKS_KERNEL_VERSION: "6.1.0"}),
+				makeTestContainer("b", map[string]string{HOSTOS_BLOCKS_KERNEL_VERSION: "5.15.0"}),
+			},
+			kernelVersion: "",
+			expectNames:   []string{"a", "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterByKernelVersion(tt.containers, tt.kernelVersion)
+			var gotNames []string
+			for _, c := range result {
+				gotNames = append(gotNames, c.Name)
+			}
+			if !reflect.DeepEqual(gotNames, tt.expectNames) {
+				t.Errorf("expected %v, got %v", tt.expectNames, gotNames)
+			}
+		})
+	}
+}
+
+func TestComputeABIID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Module.symvers")
+	content := []byte("0xdeadbeef\tsome_symbol\tvmlinux\tEXPORT_SYMBOL\n")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	expected := sha256.Sum256(content)
+	want := hex.EncodeToString(expected[:])
+
+	got, err := ComputeABIID(path)
+	if err != nil {
+		t.Fatalf("ComputeABIID: %v", err)
+	}
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+
+	if _, err := ComputeABIID(filepath.Join(dir, "nope")); err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestParseHostKernelABIID(t *testing.T) {
+	abi := strings.Repeat("a", 64)
+	tests := []struct {
+		name    string
+		cmdline string
+		want    string
+	}{
+		{"absent", "console=ttyS0 root=UUID=xxx rootwait", ""},
+		{"empty", "", ""},
+		{"present alone", "balena_kernel_abi=" + abi, abi},
+		{"present among others", "console=ttyS0 balena_kernel_abi=" + abi + " rootwait", abi},
+		{"trailing newline", "ro balena_kernel_abi=" + abi + "\n", abi},
+		{"empty value", "ro balena_kernel_abi= rootwait", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseHostKernelABIID(tt.cmdline); got != tt.want {
+				t.Errorf("ParseHostKernelABIID(%q) = %q, want %q", tt.cmdline, got, tt.want)
+			}
+		})
+	}
+}
+
+// writeConfigV2 writes the given root map as config.v2.json in a temp home
+// directory and returns a Container with HomePath populated. The Labels map
+// is linked to the one written into the JSON so in-memory state matches disk.
+func writeConfigV2(t *testing.T, name string, labels map[string]string, extra map[string]interface{}) Container {
+	t.Helper()
+	home := t.TempDir()
+	jsonLabels := map[string]interface{}{}
+	for k, v := range labels {
+		jsonLabels[k] = v
+	}
+	cfg := map[string]interface{}{
+		"Labels": jsonLabels,
+	}
+	if extra != nil {
+		if cfgExtra, ok := extra["Config"].(map[string]interface{}); ok {
+			for k, v := range cfgExtra {
+				cfg[k] = v
+			}
+		}
+	}
+	root := map[string]interface{}{
+		"ID":     "cid-" + name,
+		"Name":   name,
+		"Driver": "overlay2",
+		"Config": cfg,
+	}
+	if extra != nil {
+		for k, v := range extra {
+			if k == "Config" {
+				continue
+			}
+			root[k] = v
+		}
+	}
+	out, err := json.Marshal(root)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config.v2.json"), out, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	c := Container{
+		Config: Config{
+			HostConfig: HostConfig{Labels: map[string]string{}},
+			Name:       name,
+			ID:         "cid-" + name,
+			Driver:     "overlay2",
+		},
+		HomePath: home,
+	}
+	for k, v := range labels {
+		c.Labels[k] = v
+	}
+	return c
+}
+
+// writeModuleSymvers creates <mount>/lib/modules/<release>/Module.symvers with
+// the given content under a fresh temp dir, sets it as the container's
+// MountPath, and returns the sha256 the resolver must compute.
+func writeModuleSymvers(t *testing.T, c *Container, release string, content []byte) string {
+	t.Helper()
+	mount := t.TempDir()
+	modDir := filepath.Join(mount, "lib", "modules", release)
+	if err := os.MkdirAll(modDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modDir, "Module.symvers"), content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	c.MountPath = mount
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestResolveExtensionABIID(t *testing.T) {
+	// A fixed release decouples the fixtures from the host's running kernel.
+	const release = "6.1.0-test"
+
+	t.Run("empty MountPath returns empty (agnostic)", func(t *testing.T) {
+		c := writeConfigV2(t, "no-mount", nil, nil)
+		// MountPath deliberately left empty.
+		got, err := c.ResolveExtensionABIID(release)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("no /lib/modules returns empty (agnostic)", func(t *testing.T) {
+		c := writeConfigV2(t, "no-modules", nil, nil)
+		c.MountPath = t.TempDir()
+		got, err := c.ResolveExtensionABIID(release)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("empty release on an agnostic extension passes (no ABI claim)", func(t *testing.T) {
+		c := writeConfigV2(t, "agnostic-unknown-release", nil, nil)
+		c.MountPath = t.TempDir()
+		got, err := c.ResolveExtensionABIID("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("empty release on a module-carrying extension is an error (fail-closed)", func(t *testing.T) {
+		c := writeConfigV2(t, "kernel-unknown-release", nil, nil)
+		writeModuleSymvers(t, &c, release, []byte("symvers-fixture\n"))
+		if _, err := c.ResolveExtensionABIID(""); err == nil {
+			t.Error("expected error when running kernel release is unknown")
+		}
+	})
+
+	t.Run("modules dir without Module.symvers is an error (broken)", func(t *testing.T) {
+		c := writeConfigV2(t, "broken", nil, nil)
+		mount := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(mount, "lib", "modules", release), 0755); err != nil {
+			t.Fatal(err)
+		}
+		c.MountPath = mount
+		if _, err := c.ResolveExtensionABIID(release); err == nil {
+			t.Error("expected error for missing Module.symvers")
+		}
+	})
+
+	t.Run("Module.symvers present computes sha without writing it back", func(t *testing.T) {
+		c := writeConfigV2(t, "disco", nil, nil)
+		want := writeModuleSymvers(t, &c, release, []byte("ext-symvers-fixture\n"))
+
+		got, err := c.ResolveExtensionABIID(release)
+		if err != nil {
+			t.Fatalf("ResolveExtensionABIID: %v", err)
+		}
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+		// The label is not persisted: the build bakes it onto the image, so
+		// mobynit must not mutate config.v2.json in the early-boot path.
+		if _, ok := c.Labels[HOSTOS_BLOCKS_KERNEL_ABI_ID]; ok {
+			t.Errorf("in-memory label should not be set, got %v", c.Labels)
+		}
+		raw, _ := os.ReadFile(filepath.Join(c.HomePath, "config.v2.json"))
+		var root map[string]interface{}
+		_ = json.Unmarshal(raw, &root)
+		labels, _ := root["Config"].(map[string]interface{})["Labels"].(map[string]interface{})
+		if _, ok := labels[HOSTOS_BLOCKS_KERNEL_ABI_ID]; ok {
+			t.Errorf("config.v2.json should not be written back, got labels %v", labels)
+		}
+	})
+
+	t.Run("label matching computed value passes", func(t *testing.T) {
+		c := writeConfigV2(t, "consistent", nil, nil)
+		want := writeModuleSymvers(t, &c, release, []byte("consistent-fixture\n"))
+		c.Labels[HOSTOS_BLOCKS_KERNEL_ABI_ID] = want
+
+		got, err := c.ResolveExtensionABIID(release)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("label disagreeing with computed value is an error", func(t *testing.T) {
+		c := writeConfigV2(t, "inconsistent", nil, nil)
+		writeModuleSymvers(t, &c, release, []byte("inconsistent-fixture\n"))
+		c.Labels[HOSTOS_BLOCKS_KERNEL_ABI_ID] = "deadbeef-bogus-label"
+
+		if _, err := c.ResolveExtensionABIID(release); err == nil {
+			t.Error("expected error when label disagrees with computed sha256")
+		}
+	})
+}
+
+// abiKind selects how buildFilterContainer provisions an extension's mount.
+type abiKind int
+
+const (
+	abiAgnostic abiKind = iota // no /lib/modules/<release>: makes no ABI claim
+	abiBroken                  // /lib/modules/<release> present but Module.symvers missing
+	abiKernel                  // Module.symvers present, ABI = sha256(content)
+)
+
+// buildFilterContainer materialises a container exactly as FilterByKernelABIID
+// will see it: ABI-agnostic, broken, or kernel-carrying with a known symvers
+// content (so the caller can compute the matching host ABI).
+func buildFilterContainer(t *testing.T, name string, release string, kind abiKind, symvers []byte) Container {
+	t.Helper()
+	c := writeConfigV2(t, name, nil, nil)
+	switch kind {
+	case abiAgnostic:
+		c.MountPath = t.TempDir()
+	case abiBroken:
+		mount := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(mount, "lib", "modules", release), 0755); err != nil {
+			t.Fatal(err)
+		}
+		c.MountPath = mount
+	case abiKernel:
+		writeModuleSymvers(t, &c, release, symvers)
+	}
+	return c
+}
+
+func abiOf(symvers []byte) string {
+	sum := sha256.Sum256(symvers)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestFilterByKernelABIID(t *testing.T) {
+	const release = "6.1.0-test"
+
+	abiA := []byte("abi-A-symvers\n")
+	abiB := []byte("abi-B-symvers\n")
+	hostA := abiOf(abiA)
+
+	tests := []struct {
+		name        string
+		containers  []Container
+		hostABIID   string
+		expectNames []string
+	}{
+		{
+			name: "agnostic extension passes when host ABI present",
+			containers: []Container{
+				buildFilterContainer(t, "agnostic", release, abiAgnostic, nil),
+			},
+			hostABIID:   hostA,
+			expectNames: []string{"agnostic"},
+		},
+		{
+			name: "matching ABI mounts",
+			containers: []Container{
+				buildFilterContainer(t, "match", release, abiKernel, abiA),
+			},
+			hostABIID:   hostA,
+			expectNames: []string{"match"},
+		},
+		{
+			name: "mismatched ABI skipped",
+			containers: []Container{
+				buildFilterContainer(t, "wrong-abi", release, abiKernel, abiB),
+			},
+			hostABIID:   hostA,
+			expectNames: nil,
+		},
+		{
+			name: "broken extension skipped (fail-closed)",
+			containers: []Container{
+				buildFilterContainer(t, "broken", release, abiBroken, nil),
+			},
+			hostABIID:   hostA,
+			expectNames: nil,
+		},
+		{
+			name: "absent host ABI skips kernel block but passes agnostic (fail-closed)",
+			containers: []Container{
+				buildFilterContainer(t, "kernel", release, abiKernel, abiA),
+				buildFilterContainer(t, "agnostic", release, abiAgnostic, nil),
+			},
+			hostABIID:   "",
+			expectNames: []string{"agnostic"},
+		},
+		{
+			name: "mixed: only the ABI-matching kernel block and agnostic pass",
+			containers: []Container{
+				buildFilterContainer(t, "match", release, abiKernel, abiA),
+				buildFilterContainer(t, "wrong-abi", release, abiKernel, abiB),
+				buildFilterContainer(t, "agnostic", release, abiAgnostic, nil),
+			},
+			hostABIID:   hostA,
+			expectNames: []string{"match", "agnostic"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterByKernelABIID(tt.containers, release, tt.hostABIID)
+			var gotNames []string
+			for _, c := range result {
+				gotNames = append(gotNames, c.Name)
+			}
+			if !reflect.DeepEqual(gotNames, tt.expectNames) {
+				t.Errorf("expected %v, got %v", tt.expectNames, gotNames)
+			}
+		})
+	}
+}
+
+// pathIsMounted reports whether path is a mount point, by comparing its st_dev
+// to its parent's (the technique mountpoint(1) uses). This resolves the path in
+// the calling thread's mount namespace, so it works under CLONE_NEWNS: unlike
+// /proc/self/mountinfo, which reflects the thread-group leader's namespace, not
+// the unshared test thread's.
+func pathIsMounted(t *testing.T, path string) bool {
+	t.Helper()
+	var st, parent unix.Stat_t
+	if err := unix.Lstat(path, &st); err != nil {
+		t.Fatalf("lstat %s: %v", path, err)
+	}
+	if err := unix.Lstat(filepath.Dir(path), &parent); err != nil {
+		t.Fatalf("lstat %s: %v", filepath.Dir(path), err)
+	}
+	return st.Dev != parent.Dev
+}
+
+// TestSelectMountable verifies that SelectMountable releases the overlay
+// mounts of dropped candidates while leaving the selected set mounted.
+func TestSelectMountable(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root to mount/unmount")
+	}
+	// Pin to one OS thread so the unshare, the mounts, and the mountinfo read
+	// all run in the same (unshared) mount namespace; otherwise the Go
+	// scheduler can migrate the goroutine across threads in different namespaces.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	// Isolate so the test's mounts never leak into the host namespace.
+	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
+		t.Fatalf("unshare: %v", err)
+	}
+	if err := unix.Mount("", "/", "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
+		t.Fatalf("make mounts private: %v", err)
+	}
+
+	mkMount := func(name string) string {
+		dir := filepath.Join(t.TempDir(), name)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if err := unix.Mount("tmpfs", dir, "tmpfs", 0, ""); err != nil {
+			t.Fatalf("mounting tmpfs at %s: %v", dir, err)
+		}
+		return dir
+	}
+
+	keepPath := mkMount("keep")
+	dropPath := mkMount("drop")
+	// Best-effort teardown (dropPath is already unmounted by the call under test).
+	defer unix.Unmount(keepPath, unix.MNT_DETACH)
+	defer unix.Unmount(dropPath, unix.MNT_DETACH)
+
+	// The running release is 6.0.0; dropid's kernel-version label (0.0.0)
+	// mismatches, so SelectMountable drops and unmounts it; keepid is unlabelled
+	// and survives. Neither carries kernel modules, so the ABI filter passes both.
+	all := []Container{
+		{Config: Config{ID: "keepid", Name: "keep"}, MountPath: keepPath},
+		{Config: Config{
+			ID:         "dropid",
+			Name:       "drop",
+			HostConfig: HostConfig{Labels: map[string]string{HOSTOS_BLOCKS_KERNEL_VERSION: "0.0.0"}},
+		}, MountPath: dropPath},
+	}
+
+	selected := SelectMountable(all, "6.0.0", "")
+	if len(selected) != 1 || selected[0].ID != "keepid" {
+		t.Fatalf("expected only keepid selected, got %+v", selected)
+	}
+
+	// Selected candidate stays mounted and keeps its MountPath.
+	if !pathIsMounted(t, keepPath) {
+		t.Errorf("selected overlay should still be mounted at %s", keepPath)
+	}
+	if all[0].MountPath != keepPath {
+		t.Errorf("selected MountPath changed: %q", all[0].MountPath)
+	}
+	// Dropped candidate is unmounted and its MountPath cleared.
+	if pathIsMounted(t, dropPath) {
+		t.Errorf("dropped overlay should have been unmounted at %s", dropPath)
+	}
+	if all[1].MountPath != "" {
+		t.Errorf("dropped MountPath should be cleared, got %q", all[1].MountPath)
+	}
 }


### PR DESCRIPTION
Extensions can contain two labels (container labels or image labels, with container labels taking precedence):

* io.balena.image.kernel-version: user space ABI in the form M.m.p revision
* io.balena.image.kernel-abi-id: kernel space ABI as a sha256 of the Modules.symver file.

Change-type: patch